### PR TITLE
Fix deploy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 > The deploy button will guide you through the setup for CF_API_TOKEN and CF_ACCOUNT_ID on the UI. But you are still required to provide the REMIX_TOKEN as a repository secret yourself for the deploy action to work properly.
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/edmundhung/remix-worker-template)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/jacob-ebey/cloudflare-remix-prisma)
 
 ## Development
 


### PR DESCRIPTION
The deploy link was still set to the source template repo